### PR TITLE
Fix email field

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -11,9 +11,21 @@
 				CREATE TABLE `tbl_fields_email` (
 					`id` int(11) unsigned NOT NULL auto_increment,
 					`field_id` int(11) unsigned NOT NULL,
+					`validator` varchar(255) default NULL,
 					PRIMARY KEY  (`id`),
 					KEY `field_id` (`field_id`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 			");
+		}
+
+		public function update($previousVersion = false){
+
+			if (version_compare($previousVersion, '1.2.2', '<=')) {
+				Symphony::Database()->query(
+					"ALTER TABLE `tbl_fields_email`
+					ADD COLUMN `validator` varchar(255) default NULL;"
+				);
+			}
+
 		}
 	}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -11,21 +11,9 @@
 				CREATE TABLE `tbl_fields_email` (
 					`id` int(11) unsigned NOT NULL auto_increment,
 					`field_id` int(11) unsigned NOT NULL,
-					`validator` varchar(255) default NULL,
 					PRIMARY KEY  (`id`),
 					KEY `field_id` (`field_id`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 			");
-		}
-
-		public function update($previousVersion = false){
-
-			if (version_compare($previousVersion, '1.2.2', '<=')) {
-				Symphony::Database()->query(
-					"ALTER TABLE `tbl_fields_email`
-					ADD COLUMN `validator` varchar(255) default NULL;"
-				);
-			}
-
 		}
 	}

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -13,6 +13,11 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.2.2" date="2016-08-15" min="2.3">
+			- Supported on PHP 7
+			- Added update for older version
+			- Fixed install missing validator
+		</release>
 		<release version="1.2.1" date="2013-02-25" min="2.3">
 			- Minor updates to method signatures for forward compatibility
 		</release>

--- a/fields/field.email.php
+++ b/fields/field.email.php
@@ -50,9 +50,15 @@
 		public function displaySettingsPanel(XMLElement &$wrapper, $errors = null) {
 			parent::displaySettingsPanel($wrapper, $errors);
 
+			if ($this->get('id')) {
+				$wrapper->removeChildAt(5);
+				$wrapper->removeChildAt(4);
+			} else {
+				$wrapper->removeChildAt(4);
+				$wrapper->removeChildAt(3);
+			}
 			$div = new XMLElement('div', NULL, array('class' => 'two columns'));
-			$this->appendRequiredCheckbox($div);
-			$this->appendShowColumnCheckbox($div);
+			
 			$wrapper->appendChild($div);
 		}
 

--- a/fields/field.email.php
+++ b/fields/field.email.php
@@ -70,7 +70,7 @@
 
 			$fields = array();
 			$fields['field_id'] = $id;
-			
+
 			return FieldManager::saveSettings($id, $fields);
 		}
 


### PR DESCRIPTION
Issue with validator not in `tbl_fields_email`.
Removed the validator in the email_field (in edit section).

Can't unset validator in field.email : 

![field_email](https://cloud.githubusercontent.com/assets/8250836/17678040/7fb72fe6-6303-11e6-943f-4178d4718b0f.PNG)

since its hardcoded in field.input.php : 

![capture](https://cloud.githubusercontent.com/assets/8250836/17678197/283061c4-6304-11e6-9f6e-ad2916fa47eb.PNG)
